### PR TITLE
FIX tf api compatibility problem

### DIFF
--- a/autoencoders.py
+++ b/autoencoders.py
@@ -129,7 +129,10 @@ class BaseAutoencoder(BaseEstimator):
 			# self.loss = tf.mul(0.5, tf.reduce_sum(tf.square(tf.subtract(self.z, self.x))), 
 			self.loss = tf.reduce_mean(tf.square(tf.subtract(self.z, self.x)),	
 				name='Reconstruction_loss')
-			tf.summary.scalar(self.loss.op.name, self.loss)
+			if(tf.__version__.startswith("0.") and int(tf.__version__.split(".")[1])<11): # For tf version <0.12.0
+				tf.scalar_summary(self.loss.op.name, self.loss)
+			else:
+				tf.summary.scalar(self.loss.op.name, self.loss)
 
 			self.optimize_op = self.optimizer.minimize(self.loss)
 			if(tf.__version__.startswith("0.") and int(tf.__version__.split(".")[1])<12): # For tf version <0.12.0
@@ -354,7 +357,10 @@ class AdditiveGaussianNoiseAutoencoder(BaseAutoencoder):
 			# self.loss = tf.mul(0.5, tf.reduce_sum(tf.square(tf.subtract(self.z, self.x))), 
 			self.loss = tf.reduce_mean(tf.square(tf.subtract(self.z, self.x)),
 				name='Reconstruction_loss')
-			tf.summary.scalar(self.loss.op.name, self.loss)
+			if(tf.__version__.startswith("0.") and int(tf.__version__.split(".")[1])<11): # For tf version <0.12.0
+				tf.scalar_summary(self.loss.op.name, self.loss)
+			else:
+				tf.summary.scalar(self.loss.op.name, self.loss)
 
 			self.optimize_op = self.optimizer.minimize(self.loss)
 			if(tf.__version__.startswith("0.") and int(tf.__version__.split(".")[1])<12): # For tf version <0.12.0
@@ -455,7 +461,10 @@ class MaskingNoiseAutoencoder(BaseAutoencoder):
 			# self.loss = tf.mul(0.5, tf.reduce_sum(tf.square(tf.subtract(self.z, self.x))), 
 			self.loss = tf.reduce_mean(tf.square(tf.subtract(self.z, self.x)),
 				name='Reconstruction_loss')
-			tf.summary.scalar(self.loss.op.name, self.loss)
+			if(tf.__version__.startswith("0.") and int(tf.__version__.split(".")[1])<11): # For tf version <0.12.0
+				tf.scalar_summary(self.loss.op.name, self.loss)
+			else:
+				tf.summary.scalar(self.loss.op.name, self.loss)
 
 			self.optimize_op = self.optimizer.minimize(self.loss)
 			if(tf.__version__.startswith("0.") and int(tf.__version__.split(".")[1])<12): # For tf version <0.12.0

--- a/autoencoders.py
+++ b/autoencoders.py
@@ -132,8 +132,10 @@ class BaseAutoencoder(BaseEstimator):
 			tf.summary.scalar(self.loss.op.name, self.loss)
 
 			self.optimize_op = self.optimizer.minimize(self.loss)
-
-			self.init_op = tf.global_variables_initializer()
+			if(tf.__version__.startswith("0.") and int(tf.__version__.split(".")[1])<12): # For tf version <0.12.0
+				self.init_op = tf.initialize_all_variables()
+			else: # For tf version >= 0.12.0
+				self.init_op = tf.global_variables_initializer()	
 			# To save model
 			self.saver = tf.train.Saver()
 			# Summary writer for tensorboard
@@ -352,8 +354,10 @@ class AdditiveGaussianNoiseAutoencoder(BaseAutoencoder):
 			tf.summary.scalar(self.loss.op.name, self.loss)
 
 			self.optimize_op = self.optimizer.minimize(self.loss)
-
-			self.init_op = tf.global_variables_initializer()
+			if(tf.__version__.startswith("0.") and int(tf.__version__.split(".")[1])<12): # For tf version <0.12.0
+				self.init_op = tf.initialize_all_variables()
+			else: # For tf version >= 0.12.0
+				self.init_op = tf.global_variables_initializer()	
 			# To save model
 			self.saver = tf.train.Saver()
 			# Summary writer for tensorboard
@@ -448,8 +452,10 @@ class MaskingNoiseAutoencoder(BaseAutoencoder):
 			tf.summary.scalar(self.loss.op.name, self.loss)
 
 			self.optimize_op = self.optimizer.minimize(self.loss)
-
-			self.init_op = tf.global_variables_initializer()
+			if(tf.__version__.startswith("0.") and int(tf.__version__.split(".")[1])<12): # For tf version <0.12.0
+				self.init_op = tf.initialize_all_variables()
+			else: # For tf version >= 0.12.0
+				self.init_op = tf.global_variables_initializer()	
 			# To save model
 			self.saver = tf.train.Saver()
 			# Summary writer for tensorboard
@@ -544,8 +550,10 @@ class DualObjectiveAutoencoder(object):
 
 		self.loss = self.reconstruction_loss + self.supervised_loss
 		self.optimizer = optimizer.minimize(self.loss)
-
-		init_op = tf.global_variables_initializer()
+		if(tf.__version__.startswith("0.") and int(tf.__version__.split(".")[1])<12): # For tf version <0.12.0
+			init_op = tf.initialize_all_variables()
+		else: # For tf version >= 0.12.0
+			init_op = tf.global_variables_initializer()	
 		self.sess = tf.Session()
 		self.sess.run(init_op)
 

--- a/autoencoders.py
+++ b/autoencoders.py
@@ -139,7 +139,10 @@ class BaseAutoencoder(BaseEstimator):
 			# To save model
 			self.saver = tf.train.Saver()
 			# Summary writer for tensorboard
-			self.summary_op = tf.summary.merge_all()
+			if(tf.__version__.startswith("0.") and int(tf.__version__.split(".")[1])<12): # For tf version <0.12.0
+				self.summary_op = tf.merge_all_summaries()
+			else:
+				self.summary_op = tf.summary.merge_all()
 
 
 	def _init_variables(self):
@@ -361,7 +364,10 @@ class AdditiveGaussianNoiseAutoencoder(BaseAutoencoder):
 			# To save model
 			self.saver = tf.train.Saver()
 			# Summary writer for tensorboard
-			self.summary_op = tf.summary.merge_all()
+			if(tf.__version__.startswith("0.") and int(tf.__version__.split(".")[1])<12): # For tf version <0.12.0
+				self.summary_op = tf.merge_all_summaries()
+			else:
+				self.summary_op = tf.summary.merge_all()
 
 
 class MaskingNoiseAutoencoder(BaseAutoencoder):
@@ -459,7 +465,10 @@ class MaskingNoiseAutoencoder(BaseAutoencoder):
 			# To save model
 			self.saver = tf.train.Saver()
 			# Summary writer for tensorboard
-			self.summary_op = tf.summary.merge_all()
+			if(tf.__version__.startswith("0.") and int(tf.__version__.split(".")[1])<12): # For tf version <0.12.0
+				self.summary_op = tf.merge_all_summaries()
+			else:
+				self.summary_op = tf.summary.merge_all()
 
 	def partial_fit(self, X):
 		if self._to_write_summary():

--- a/nvdm.py
+++ b/nvdm.py
@@ -146,7 +146,10 @@ class NVDM(BaseEstimator, TransformerMixin):
             self.optim_dec = optimizer.apply_gradients(zip(dec_grads, dec_vars))
 
             # init op 
-            self.init_op = tf.global_variables_initializer()
+            if(tf.__version__.startswith("0.") and int(tf.__version__.split(".")[1])<12): # For tf version <0.12.0
+                self.init_op = tf.initialize_all_variables()
+            else: #For tf version >= 0.12.0
+                self.init_op = tf.global_variables_initializer() 
             # create a saver 
             self.saver = tf.train.Saver()
 


### PR DESCRIPTION
Dear developers,

I found some compatibility problems in your use of TensorFlow APIs, which might lead to crashes in a low version of TensorFlow. And I fix it for you as below:

`tf.global_variables_initializer` is the updated version of `tf.initialize_all_variables`, however, it appears until tf 0.12.0-rc0. So for version before that, it's better to use `tf.initialize_all_variables` to be safe.

@wangz10 
Hope you could take my advice and look forward to your reply! 😄